### PR TITLE
Ignoring .retry files generated by Ansible during playbook runs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -32,3 +32,5 @@ override.tf.json
 # Ignore CLI configuration files
 .terraformrc
 terraform.rc
+
+*.retry


### PR DESCRIPTION
Add .retry files to .gitignore

- Ignoring .retry files generated by Ansible during playbook runs
- These files are temporary and specific to individual runs
- Keeps the repository clean and reduces unnecessary bloat
- Prevents potential merge conflicts and confusion among team members