### PR TITLE
feat: Add system and SSH hardening roles to pritunl_playbook.yaml

### DIFF
--- a/ansible/pritunl_playbook.yaml
+++ b/ansible/pritunl_playbook.yaml
@@ -13,6 +13,16 @@
       vars:
         ansible_connection: local
 
+
+- name: Apply system hardening on Ubuntu
+  hosts: all
+  become: yes
+
+  roles:
+    - role: devsec.hardening.os_hardening
+    - role: devsec.hardening.ssh_hardening
+
+
 - name: SetupPritunl
   hosts: all
   become: yes

--- a/ansible/requirements.yml
+++ b/ansible/requirements.yml
@@ -1,0 +1,3 @@
+---
+collections:
+  - name: devsec.hardening


### PR DESCRIPTION
- Applied system hardening on Ubuntu in pritunl_playbook.yaml using devsec.hardening.os_hardening role
- Applied SSH hardening using devsec.hardening.ssh_hardening role
- Added devsec.hardening collection to requirements.yml for required roles